### PR TITLE
#862hynea7 - Hotfix - H2 Console nie otwiera się w przeglądarce

### DIFF
--- a/Java/E-montazysta/src/main/java/com/emontazysta/configuration/SecurityConfig.java
+++ b/Java/E-montazysta/src/main/java/com/emontazysta/configuration/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig  {
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        return http
                .csrf(csrf -> csrf.disable())
+               .headers(headers -> headers.frameOptions().disable())
                .authorizeHttpRequests(auth ->
                        auth.anyRequest().authenticated())
                .userDetailsService(userDetailsService)


### PR DESCRIPTION
Przeglądarka blokuje otwieranie się frame'ów konsoli H2